### PR TITLE
Generalize subscripts using collections.abc module

### DIFF
--- a/jsonpath2/subscripts/arrayindex.py
+++ b/jsonpath2/subscripts/arrayindex.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 """Array Index subscript of the parse tree."""
+from collections.abc import Sequence
 import json
 from typing import Generator
 from jsonpath2.node import MatchData
@@ -23,7 +24,7 @@ class ArrayIndexSubscript(Subscript):
 
     def match(self, root_value: object, current_value: object) -> Generator[MatchData, None, None]:
         """Match the root value against the current value."""
-        if isinstance(current_value, list):
+        if isinstance(current_value, Sequence) and not isinstance(current_value, str):
             if self.index < 0:
                 new_index = self.index + len(current_value)
 

--- a/jsonpath2/subscripts/arrayslice.py
+++ b/jsonpath2/subscripts/arrayslice.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 """Array slicing module."""
+from collections.abc import Sequence
 import itertools
 import json
 from typing import Generator
@@ -32,7 +33,7 @@ class ArraySliceSubscript(Subscript):
 
     def match(self, root_value: object, current_value: object) -> Generator[MatchData, None, None]:
         """Match an array slice between values."""
-        if isinstance(current_value, list):
+        if isinstance(current_value, Sequence) and not isinstance(current_value, str):
             start = None if (self.start is None) else (
                 self.start + (len(current_value) if (self.start < 0) else 0))
 

--- a/jsonpath2/subscripts/callable.py
+++ b/jsonpath2/subscripts/callable.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 """Callable subscript."""
+from collections.abc import Mapping, Sequence
 import itertools
 import json
 from typing import Generator, Tuple, Union
@@ -80,13 +81,13 @@ class EntriesCallableSubscript(CallableSubscript):
 
     def __call__(self, root_value: object, current_value: object) -> Generator[MatchData, None, None]:
         """Perform entries() call."""
-        if isinstance(current_value, dict):
+        if isinstance(current_value, Mapping):
             if not self.args:
                 value = list(map(list, current_value.items()))
 
                 yield MatchData(SubscriptNode(TerminalNode(), [self]),
                                 root_value, value)
-        elif isinstance(current_value, list):
+        elif isinstance(current_value, Sequence) and not isinstance(current_value, str):
             if not self.args:
                 value = list(map(list, enumerate(current_value)))
 
@@ -101,13 +102,13 @@ class KeysCallableSubscript(CallableSubscript):
 
     def __call__(self, root_value: object, current_value: object) -> Generator[MatchData, None, None]:
         """Perform keys() call."""
-        if isinstance(current_value, dict):
+        if isinstance(current_value, Mapping):
             if not self.args:
                 value = list(current_value.keys())
 
                 yield MatchData(SubscriptNode(TerminalNode(), [self]),
                                 root_value, value)
-        elif isinstance(current_value, list):
+        elif isinstance(current_value, Sequence) and not isinstance(current_value, str):
             if not self.args:
                 value = list(range(len(current_value)))
 
@@ -122,7 +123,7 @@ class LengthCallableSubscript(CallableSubscript):
 
     def __call__(self, root_value: object, current_value: object) -> Generator[MatchData, None, None]:
         """Perform length() call."""
-        if isinstance(current_value, list):
+        if isinstance(current_value, Sequence) and not isinstance(current_value, str):
             if not self.args:
                 value = len(current_value)
 
@@ -166,13 +167,13 @@ class ValuesCallableSubscript(CallableSubscript):
 
     def __call__(self, root_value: object, current_value: object) -> Generator[MatchData, None, None]:
         """Perform values() call."""
-        if isinstance(current_value, dict):
+        if isinstance(current_value, Mapping):
             if not self.args:
                 value = list(current_value.values())
 
                 yield MatchData(SubscriptNode(TerminalNode(), [self]),
                                 root_value, value)
-        elif isinstance(current_value, list):
+        elif isinstance(current_value, Sequence) and not isinstance(current_value, str):
             if not self.args:
                 value = current_value
 

--- a/jsonpath2/subscripts/objectindex.py
+++ b/jsonpath2/subscripts/objectindex.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 """Object index subscript module."""
+from collections.abc import Mapping
 import json
 from typing import Generator
 from jsonpath2.node import MatchData
@@ -23,6 +24,6 @@ class ObjectIndexSubscript(Subscript):
 
     def match(self, root_value: object, current_value: object) -> Generator[MatchData, None, None]:
         """Match the current value against the root value."""
-        if isinstance(current_value, dict) and (self.index in current_value):
+        if isinstance(current_value, Mapping) and (self.index in current_value):
             return [MatchData(SubscriptNode(TerminalNode(), [self]), root_value, current_value[self.index])]
         return []

--- a/jsonpath2/subscripts/wildcard.py
+++ b/jsonpath2/subscripts/wildcard.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 """Wild cart subscript module."""
+from collections.abc import Mapping, Sequence
 import itertools
 from typing import Generator
 from jsonpath2.node import MatchData
@@ -18,12 +19,12 @@ class WildcardSubscript(Subscript):
 
     def match(self, root_value: object, current_value: object) -> Generator[MatchData, None, None]:
         """Match the root value against the current value."""
-        if isinstance(current_value, dict):
+        if isinstance(current_value, Mapping):
             return itertools.chain(*map(
                 lambda index: ObjectIndexSubscript(
                     index).match(root_value, current_value),
                 current_value.keys()))
-        if isinstance(current_value, list):
+        if isinstance(current_value, Sequence) and not isinstance(current_value, str):
             return itertools.chain(*map(
                 lambda index: ArrayIndexSubscript(
                     index).match(root_value, current_value),


### PR DESCRIPTION
### Description

Replaces `isinstance(x, dict)` with `isinstance(x, collections.abc.Mapping)`.

Replaces `isinstance(x, list)` with `isinstance(x, collections.abc.Sequence) and not isinstance(x, str)`.

### Issues Resolved

Closes #20

### Check List

- [x] All tests pass.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
