### PR TITLE
Use shorter idiomatic python for README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ The `jsonpath2.path.Path` class represents a JSONPath.
 >>> from jsonpath2.path import Path
 >>> p = Path.parse_str('$["hello"]')
 <jsonpath2.path.Path object>
->>> list(map(lambda match_data: match_data.current_value, p.match(d)))
+>>> [match_data.current_value for match_data in p.match(d)]
 ['Hello, world!']
->>> list(map(lambda match_data: match_data.node.tojsonpath(), p.match(d)))
+>>> [match_data.node.tojsonpath() for match_data in p.match(d)]
 ['$["hello"]']
 ```
 
@@ -130,9 +130,9 @@ The syntax for a function call is the name of the function followed by the argum
 >>> from jsonpath2.path import Path
 >>> p = Path.parse_str('$["hello"][length()]')
 <jsonpath2.path.Path object>
->>> list(map(lambda match_data: match_data.current_value, p.match(d)))
+>>> [m.current_value for m in p.match(d)]
 [13]
->>> list(map(lambda match_data: match_data.node.tojsonpath(), p.match(d)))
+>>> [m.node.tojsonpath() for m in p.match(d)]
 ['$["hello"][length()]']
 ```
 


### PR DESCRIPTION
### Description

This change improves readability of examples in README page.

Several sources suggests that List comprehensions are more idiomatic than `map()` or `filter()` builtins, even Pylint raises a [warning](http://pylint-messages.wikidot.com/messages:w0141) when these builtins are used.
- https://docs.quantifiedcode.com/python-anti-patterns/readability/using_map_or_filter_where_list_comprehension_is_possible.html
- https://stackoverflow.com/questions/1247486/list-comprehension-vs-map

### Issues Resolved

None, I was just passing by looking for a JsonPath implementation and the examples caught my attention.

### Check List

- [x] All tests pass.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
