### PR TITLE
Add handy shortcut to match string path

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,19 @@ This repository contains an implementation of [JSONPath](http://goessner.net/art
 
 ## API
 
+
+### `match` shortcut function
+
+The `jsonpath2.match` function is a shortcut to match a given JSON data
+structure against a JSONPath string
+
+```python
+>>> import jsonpath2
+>>> doc = {'hello': 'Hello, world!'}
+>>> [x.current_value for x in jsonpath2.match('$.hello', doc)]
+['Hello, world!']
+```
+
 ### `Path` class
 
 The `jsonpath2.path.Path` class represents a JSONPath.

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ The `jsonpath2.path.Path` class represents a JSONPath.
 >>> from jsonpath2.path import Path
 >>> p = Path.parse_str('$["hello"]')
 <jsonpath2.path.Path object>
->>> list(map(lambda match_data: match_data.current_value, p.match(d)))
+>>> [match_data.current_value for match_data in p.match(d)]
 ['Hello, world!']
->>> list(map(lambda match_data: match_data.node.tojsonpath(), p.match(d)))
+>>> [match_data.node.tojsonpath() for match_data in p.match(d)]
 ['$["hello"]']
 ```
 
@@ -130,9 +130,9 @@ The syntax for a function call is the name of the function followed by the argum
 >>> from jsonpath2.path import Path
 >>> p = Path.parse_str('$["hello"][length()]')
 <jsonpath2.path.Path object>
->>> list(map(lambda match_data: match_data.current_value, p.match(d)))
+>>> [m.current_value for m in p.match(d)]
 [13]
->>> list(map(lambda match_data: match_data.node.tojsonpath(), p.match(d)))
+>>> [m.node.tojsonpath() for m in p.match(d)]
 ['$["hello"][length()]']
 ```
 

--- a/jsonpath2/__init__.py
+++ b/jsonpath2/__init__.py
@@ -1,3 +1,13 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 """The jsonpath2 module."""
+
+from typing import Generator
+from .path import Path
+from .node import MatchData
+
+
+def match(path_str: str, root_value: object) -> Generator[MatchData, None, None]:
+    """Match root value of the path."""
+    path = Path.parse_str(path_str)
+    return path.match(root_value)

--- a/jsonpath2/test/shortcuts_test.py
+++ b/jsonpath2/test/shortcuts_test.py
@@ -1,0 +1,18 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+"""Test package level shortcuts."""
+
+from unittest import TestCase
+import jsonpath2
+
+
+class TestShortcuts(TestCase):
+    """Test package level shortcuts."""
+
+    def test_match(self):
+        """Test match shortcut works."""
+        data = {'hello': 'Hello, World!'}
+        self.assertEqual(
+            [x.current_value for x in jsonpath2.match('$.hello', data)],
+            ['Hello, World!']
+        )


### PR DESCRIPTION
**[WIP]  Opened to measure acceptance by maintainers. 
Tests and docs will be updated once API is agreed (if any)**

### Description

This change aims to avoid the boilerplate of applying a JsonPath to a document

```python
>>> import jsonpath2 as jsonpath
>>> doc = {'hello': 'Hello, world!'}
>>> [m.current_value for m in jsonpath.match('$["hello"]', doc)]
```

It resembles the use of `re` module in `re.match(pattern, string)` vs `re.compile(pattern).match(string)`

### Issues Resolved

None.

### Check List

- [x] All tests pass.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
