### PR TITLE
Fix #31 Fixes start of arrayslice

### DIFF
--- a/jsonpath2/subscripts/arrayslice.py
+++ b/jsonpath2/subscripts/arrayslice.py
@@ -35,7 +35,9 @@ class ArraySliceSubscript(Subscript):
         """Match an array slice between values."""
         if isinstance(current_value, Sequence) and not isinstance(current_value, str):
             start = None if (self.start is None) else (
-                self.start + (len(current_value) if (self.start < 0) else 0))
+                self.start + ((
+                    len(current_value) if abs(self.start) < len(current_value) else abs(self.start)
+                ) if (self.start < 0) else 0))
 
             end = None if (self.end is None) else (
                 self.end + (len(current_value) if (self.end < 0) else 0))

--- a/tests/arrayslice_subscript_test.py
+++ b/tests/arrayslice_subscript_test.py
@@ -75,3 +75,17 @@ class TestArraySliceSubscript(TestCase):
         root_value = None
         self.assertTrue(not isinstance(root_value, list))
         self.assertEqual([], list(subscript.match(root_value, root_value)))
+
+    def test_arrayslice8(self):
+        """Test the arrayslice with configuration 1000 (base 2)."""
+        subscript = ArraySliceSubscript(-15, None, None)
+        self.assertEqual('-15:', subscript.tojsonpath())
+        self.assertEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], list(map(
+            lambda match_data: match_data.current_value, subscript.match(self.root_value, self.current_value))))
+
+    def test_arrayslice9(self):
+        """Test the arrayslice with configuration 1001 (base 2)."""
+        subscript = ArraySliceSubscript(None, -15, None)
+        self.assertEqual(':-15', subscript.tojsonpath())
+        self.assertEqual([], list(map(
+            lambda match_data: match_data.current_value, subscript.match(self.root_value, self.current_value))))


### PR DESCRIPTION
### Description

This makes sure start of arrayslice is actually 0 before we start
the processing of arrayslice subscripts.

Signed-off-by: David Brown <dmlb2000@gmail.com>

### Issues Resolved

Fix #31 
### Check List

- [x] All tests pass.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
